### PR TITLE
Integrate chatbot crate

### DIFF
--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 miniserve = { path = "../miniserve" }
+chatbot = { path = "../chatbot" }
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.121"
 tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
Reference solution for integrating the chatbot crate. Key changes:
* `tokio::join` is used to poll both futures simultaneously.
* Use the random number modulo `responses.len()` to index the responses vector.